### PR TITLE
display competition  options in 2 columns

### DIFF
--- a/app/assets/stylesheets/_form.scss
+++ b/app/assets/stylesheets/_form.scss
@@ -18,7 +18,7 @@ div.field label {
 }
 
 .checkbox-group input[type=checkbox] {
-  width: 100px;
+  width: 50px;
 }
 
 .checkbox-group label {
@@ -52,4 +52,11 @@ select, input {
 
 input.form-btn {
   text-align: center;
+}
+
+.competition-options {
+  display: grid; 
+  grid-template-columns: repeat(2, 1fr);
+  max-width: 475px;
+  margin: 0 auto;
 }

--- a/app/views/clubs/_form.html.erb
+++ b/app/views/clubs/_form.html.erb
@@ -33,12 +33,14 @@
   <div class="field">
     <%= form.label "Competitions" %>
     <%= hidden_field_tag "club[competition_ids][]", nil %>
+    <div class="competition-options">
     <% Competition.all.each do |competition| %>
       <div class="checkbox-group">
         <%= check_box_tag "club[competition_ids][]", competition.id, @club.competitions.include?(competition), id: dom_id(competition) %>
         <%= label_tag dom_id(competition), competition.name %>
       </div>
     <% end %>
+    </div>
     </div>
 
   <div class="field">


### PR DESCRIPTION
Add grid to the competitions checkbock container to display the options in two colums. The width does not exceed that of the other inputs