### PR TITLE
Fix stream item grid

### DIFF
--- a/app/assets/stylesheets/home.scss
+++ b/app/assets/stylesheets/home.scss
@@ -50,11 +50,11 @@ Slight border radius. Fixed height. Slight shadow to add depth
 .stream-item {
   position: relative;
   display: grid;
-  grid-template-columns: repeat(1, 60px) auto;
+  grid-template-columns: 60px auto;
   grid-template-rows: 2fr 1fr;
   grid-gap: 0;
   width: 100%;
-  height: 150px;
+  height: auto;
   background-color: #fff;
   border-radius: 10px 2px 2px 10px;
   box-shadow: rgba(0, 0, 0, 0.2) 2px 2px 12px;
@@ -103,7 +103,7 @@ a:visited, .live i {
 .teams {
   display: grid;
   grid-template-columns: 1fr auto 1fr;
-  grid-column: 3/4;
+  grid-column: 2/3;
   grid-row: 1/2;
   align-items: center;
 }
@@ -202,7 +202,7 @@ top border grey */
   grid-template-columns: repeat(3, 1fr);
   grid-template-rows: 1fr;
   align-items: center;
-  grid-column: 3/4;
+  grid-column: 2/3;
   grid-row: 2/3;
   padding: 10px;
   border-top: 1px solid rgba(207, 207, 207, 0.5);


### PR DESCRIPTION
Remove unneccessary grid column that is only visible when there is one item per row (small screens)